### PR TITLE
Fixes for crate attribute syntax changes

### DIFF
--- a/src/redis/lib.rs
+++ b/src/redis/lib.rs
@@ -1,7 +1,7 @@
-#[crate_id = "redis#0.1"];
-#[desc = "A Rust client library for Redis"];
-#[license = "MIT"];
-#[crate_type = "lib"];
+#![crate_id = "redis#0.1"]
+#![desc = "A Rust client library for Redis"]
+#![license = "MIT"]
+#![crate_type = "lib"]
 
 use std::io::{IoResult,IoError,InvalidInput};
 use std::io::net::ip::SocketAddr;


### PR DESCRIPTION
Trying to fix errors with the latest version of rust. 

More commits incoming!

(I am also learning rust this way, so might take a bit)
